### PR TITLE
added function for initializing segments for builtins in form of columns next to 'Execution'

### DIFF
--- a/src/vm.ts
+++ b/src/vm.ts
@@ -24,7 +24,43 @@ const dstColumn: String = columns[i];
 i++;
 const executionColumn: String = columns[i];
 i++;
+
+type builtins = {
+  output: string;
+  pedersen: string;
+  range_check: string;
+  ecdsa: string;
+  bitwise: string;
+  ec_op: string;
+  keccak: string;
+  poseidon: string;
+};
+
+const builtins = {
+  "output": null,
+  "pedersen": null,
+  "range_check": null,
+  "ecdsa": null,
+  "bitwise": null,
+  "ec_op": null,
+  "keccak": null,
+  "poseidon": null,
+};
+
 const program: any[][] = programSheet.getRange("A2:A").getValues();
+
+function initialize_builtins(): void {
+  const keys: string[] = Object.keys(builtins);
+  for (var key of keys) {
+    console.log(`${key}: ${columns[i]}`);
+    builtins[key] = columns[i];
+    i++;
+  }
+  console.log(`${builtins[keys[0]]}1:${builtins[keys[keys.length - 1]]}1`);
+  runSheet
+    .getRange(`${builtins[keys[0]]}1:${builtins[keys[keys.length - 1]]}1`)
+    .setValues([keys]);
+}
 
 function step(n: number = 0): void {
   runSheet
@@ -32,6 +68,7 @@ function step(n: number = 0): void {
     .setValues([
       ["PC", "FP", "AP", "Opcode", "Op0", "Op1", "Res", "Dst", "Execution"],
     ]);
+  initialize_builtins();
   const registersAddress: RegistersType = {
     PC: `${pcColumn}${n + 2}`,
     FP: `${fpColumn}${n + 2}`,

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -69,7 +69,6 @@ function step(n: number = 0): void {
     .setValues([
       ["PC", "FP", "AP", "Opcode", "Op0", "Op1", "Res", "Dst", "Execution"],
     ]);
-  initialize_builtins();
   const registersAddress: RegistersType = {
     PC: `${pcColumn}${n + 2}`,
     FP: `${fpColumn}${n + 2}`,
@@ -271,6 +270,7 @@ function step(n: number = 0): void {
 }
 
 function runUntilPc() {
+  initialize_builtins();
   for (let i = 0; i < 37; i++) {
     step(i);
   }

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -50,13 +50,14 @@ const builtins = {
 const program: any[][] = programSheet.getRange("A2:A").getValues();
 
 function initialize_builtins(): void {
+  let counter: number = 0;
+  const executionColumnOffset: number = columns.indexOf(executionColumn) + 1;
   const keys: string[] = Object.keys(builtins);
+
   for (var key of keys) {
-    console.log(`${key}: ${columns[i]}`);
-    builtins[key] = columns[i];
-    i++;
+    builtins[key] = columns[counter + executionColumnOffset];
+    counter++;
   }
-  console.log(`${builtins[keys[0]]}1:${builtins[keys[keys.length - 1]]}1`);
   runSheet
     .getRange(`${builtins[keys[0]]}1:${builtins[keys[keys.length - 1]]}1`)
     .setValues([keys]);

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -37,14 +37,14 @@ type builtins = {
 };
 
 const builtins = {
-  "output": null,
-  "pedersen": null,
-  "range_check": null,
-  "ecdsa": null,
-  "bitwise": null,
-  "ec_op": null,
-  "keccak": null,
-  "poseidon": null,
+  output: null,
+  pedersen: null,
+  range_check: null,
+  ecdsa: null,
+  bitwise: null,
+  ec_op: null,
+  keccak: null,
+  poseidon: null,
 };
 
 const program: any[][] = programSheet.getRange("A2:A").getValues();


### PR DESCRIPTION
# Initialize segments for builtins

Time spent on this PR: 0.7 days (Most went into understanding the issue)

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There was no function and no memory segments being segregated for the builtins

Resolves #3 

## What is the new behavior?

There is now a method to initialize those memory segments that is being called after initializing the execution segments.