### PR TITLE
added run method and 2 constants for FINAL_FP and FINAL_PC

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -81,3 +81,6 @@ const FpUpdates: FpUpdatesType = {
   Dst: "Dst",
   ApPlus2: "AP + 2",
 };
+
+const FINAL_FP: string = "<FINAL_FP>";
+const FINAL_PC: string = "<FINAL_PC>";

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -269,19 +269,13 @@ function step(n: number = 0): void {
   runSheet.getRange(`${apColumn}${n + 2 + 1}`).setValue(newAp);
 }
 
-function run() {
-  let i: number = 0;
+function runUntilPc(): void {
+  let i: number = getLastActiveRowIndex(`${pcColumn}`) - 2;
   let pc: string = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
   while (!(pc === FINAL_PC)) {
+    console.log(i);
     step(i);
     i++;
     pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
-  }
-}
-
-function runUntilPc() {
-  initialize_builtins();
-  for (let i = 0; i < 39; i++) {
-    step(i);
   }
 }

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -272,7 +272,7 @@ function step(n: number = 0): void {
 function run() {
   let i: number = 0;
   let pc: string = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
-  while ( !(pc === FINAL_PC) ) {
+  while (!(pc === FINAL_PC)) {
     step(i);
     i++;
     pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -89,6 +89,8 @@ function step(n: number = 0): void {
   );
   runSheet.getRange(`${opcodeColumn}${n + 2}`).setValue(instruction.Opcode);
 
+  console.log(instruction);
+
   const op0Index: string =
     registers[instruction.Op0Register] + instruction.Op0Offset;
   const op1Index: string =
@@ -270,13 +272,9 @@ function step(n: number = 0): void {
 }
 
 function run() {
-  runSheet.getRange(`${executionColumn}${2 + 1}`).setValue(FINAL_FP);
-  runSheet.getRange(`${executionColumn}${3 + 1}`).setValue(FINAL_PC);
   let i: number = 0;
-
   let pc: string = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
-
-  while (!(pc === FINAL_PC || pc === FINAL_FP)) {
+  while ( !(pc === FINAL_PC) ) {
     step(i);
     i++;
     pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -198,7 +198,7 @@ function step(n: number = 0): void {
       break;
   }
 
-  let newFp: string|number;
+  let newFp: string | number;
   switch (instruction.FpUpdate) {
     case FpUpdates.Constant:
       newFp = registers[Registers.FP];
@@ -238,8 +238,8 @@ function run() {
   let i: number = 0;
 
   let pc: string = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
-  
-  while ( !(pc === FINAL_PC || pc === FINAL_FP) ) {
+
+  while (!(pc === FINAL_PC || pc === FINAL_FP)) {
     step(i);
     i++;
     pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -89,8 +89,6 @@ function step(n: number = 0): void {
   );
   runSheet.getRange(`${opcodeColumn}${n + 2}`).setValue(instruction.Opcode);
 
-  console.log(instruction);
-
   const op0Index: string =
     registers[instruction.Op0Register] + instruction.Op0Offset;
   const op1Index: string =

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -198,7 +198,7 @@ function step(n: number = 0): void {
       break;
   }
 
-  let newFp: string;
+  let newFp: string|number;
   switch (instruction.FpUpdate) {
     case FpUpdates.Constant:
       newFp = registers[Registers.FP];
@@ -207,7 +207,7 @@ function step(n: number = 0): void {
       newFp = registers[Registers.AP] + 2;
       break;
     case FpUpdates.Dst:
-      newFp = dst.getValue();
+      newFp = dstValue;
       break;
   }
 
@@ -230,6 +230,20 @@ function step(n: number = 0): void {
   runSheet.getRange(`${pcColumn}${n + 2 + 1}`).setValue(newPc);
   runSheet.getRange(`${fpColumn}${n + 2 + 1}`).setValue(newFp);
   runSheet.getRange(`${apColumn}${n + 2 + 1}`).setValue(newAp);
+}
+
+function run() {
+  runSheet.getRange(`${executionColumn}${2 + 1}`).setValue(FINAL_FP);
+  runSheet.getRange(`${executionColumn}${3 + 1}`).setValue(FINAL_PC);
+  let i: number = 0;
+
+  let pc: string = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
+  
+  while ( !(pc === FINAL_PC || pc === FINAL_FP) ) {
+    step(i);
+    i++;
+    pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
+  }
 }
 
 function runUntilPc() {


### PR DESCRIPTION
# Run implementation

Time spent on this PR: 0.2 days

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Does not have a run method. Relies on runUntilPc for running program.

Resolves #5 

## What is the new behavior?

Have implemented a run method which executes steps until current PC becomes FINAL_PC i.e. when `pc == FINAL_PC`

Good things:
- It works

Bad things:
- Very basic
- hard coded starting pc value, and does not take into consideration the number of args. Works for functions with exactly one argument
- would need refactoring or change soon when extending other behaviour or features.