### PR TITLE
bug: operations on memory addresses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,7 @@ function addSegmentValues(
     sum = `${segmentValue2[0]}${Number(segmentValue2.substring(1)) + Number(segmentValue1)}`;
   }
   if (!isCell(segmentValue1) && !isCell(segmentValue2)) {
-    sum = `${segmentValue1 + segmentValue2}`;
+    sum = `${Number(segmentValue1) + Number(segmentValue2)}`;
   }
   if (isCell(segmentValue1) && isCell(segmentValue2)) {
     if (segmentValue1[0] !== segmentValue2[0]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,55 @@ function encodeUTF8(str: string): Uint8Array {
 
   return new Uint8Array(utf8Bytes);
 }
+
+function isCell(str: string): boolean {
+  return columns.includes(str.toString().charAt(0));
+}
+
+function getFormulaOfAddition(
+  value1: string,
+  value2: string,
+  address1: string,
+  address2: string,
+): string {
+  var formula: string;
+  if (isCell(value1) && !isCell(value2)) {
+    formula = `="${value1[0]}" & (${value1.substring(1)} + ${address2})`;
+  }
+  if (!isCell(value1) && isCell(value2)) {
+    formula = `="${value2[0]}" & (${value2.substring(1)} + ${address1})`;
+  }
+  if (!isCell(value1) && !isCell(value2)) {
+    formula = `=${address1} + ${address2}`;
+  }
+  if (isCell(value1) && isCell(value2)) {
+    if (value1[0] !== value2[0]) {
+      throw new InvalidCellSumError();
+    }
+    formula = `="${value1[0]}" & (${value1.substring(1)} + ${value2.substring(1)})`;
+  }
+  return formula;
+}
+
+function addSegmentValues(
+  segmentValue1: string,
+  segmentValue2: string,
+): string {
+  var sum: string;
+  if (isCell(segmentValue1) && !isCell(segmentValue2)) {
+    sum = `${segmentValue1[0]}${Number(segmentValue1.substring(1)) + Number(segmentValue2)}`;
+  }
+  if (!isCell(segmentValue1) && isCell(segmentValue2)) {
+    sum = `${segmentValue2[0]}${Number(segmentValue2.substring(1)) + Number(segmentValue1)}`;
+  }
+  if (!isCell(segmentValue1) && !isCell(segmentValue2)) {
+    sum = `${segmentValue1 + segmentValue2}`;
+  }
+  if (isCell(segmentValue1) && isCell(segmentValue2)) {
+    if (segmentValue1[0] !== segmentValue2[0]) {
+      throw new InvalidCellSumError();
+    }
+    sum = `${segmentValue1[0]}${Number(segmentValue1.substring(1)) + Number(segmentValue2.substring(1))}`;
+  }
+  return sum;
+}

--- a/src/vm/errors.ts
+++ b/src/vm/errors.ts
@@ -8,3 +8,4 @@ class InvalidOp1RegisterError extends Error {}
 class InvalidDstRegisterError extends Error {}
 class InvalidRangeError extends Error {}
 class AssertEqError extends Error {}
+class InvalidCellSumError extends Error {}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title -->

bug: operations on memory addresses

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 2h

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #51 

## What is the new behavior?

I introduced operations on addresses using the "&" operator of google sheets:
- when summing two felts, the result is the same as usual (the cell shows the sum of the two src felts),
- when summing a felt and a cell address ("H5"), the result is "H{5+felt}",
- when summing two cell addresses, the result is "{commonColumn}{sumOfRows}"
