### PR TITLE
bug: decoding error with constants

### DIFF
--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -6,6 +6,7 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
     "Pc Update",
     "Ap Update",
     "Fp Update",
+    "Instruction size",
   ];
   try {
     if (encodedInstruction === "Program") {
@@ -14,13 +15,6 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
       const instruction: decodedInstruction = decodeInstruction(
         BigInt(encodedInstruction),
       );
-
-      if (
-        instruction.Opcode === Opcodes.NOp &&
-        instruction.PcUpdate === PcUpdates.Regular
-      ) {
-        return [["", "", toSignedInteger(encodedInstruction)]];
-      }
 
       const dst: string =
         `${instruction.DstRegister} ${instruction.DstOffset === 0 ? "" : (instruction.DstOffset > 0 ? "+ " : "- ") + Math.abs(instruction.DstOffset)}`.trim();
@@ -53,16 +47,21 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
           pcUpdate,
           instruction.ApUpdate,
           instruction.FpUpdate,
+          size(instruction)
         ],
       ];
     }
   } catch (error) {
     Logger.log(error);
     if (error instanceof NonZeroHighBitError) {
-      return [["", "", BigInt(encodedInstruction) - PRIME]];
+      return [["", "", toSignedInteger(encodedInstruction)]];
     }
     return [[""]];
   }
+}
+
+function TO_SIGNED_INTEGER(encodedInstruction: string): [any[]] {
+  return [["", "", toSignedInteger(BigInt(encodedInstruction))]];
 }
 
 /**

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -27,7 +27,7 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
       const op0: string =
         `${instruction.Op0Register} ${instruction.Op0Offset === 0 ? "" : (instruction.Op0Offset > 0 ? "+ " : "- ") + Math.abs(instruction.Op0Offset)}`.trim();
       const op1: string =
-        `${instruction.Op1Register} ${instruction.Op1Offset === 0 ? "" : (instruction.Op1Offset > 0 ? "+ " : "- ") + Math.abs(instruction.Op1Offset)}`.trim();
+        `${instruction.Op1Register === Op1Src.Op0 ? `[${op0}]` : instruction.Op1Register} ${instruction.Op1Offset === 0 ? "" : (instruction.Op1Offset > 0 ? "+ " : "- ") + Math.abs(instruction.Op1Offset)}`.trim();
 
       let op: string;
       switch (instruction.ResLogic) {

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -6,7 +6,6 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
     "Pc Update",
     "Ap Update",
     "Fp Update",
-    "Instruction size",
   ];
   try {
     if (encodedInstruction === "Program") {
@@ -47,7 +46,6 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
           pcUpdate,
           instruction.ApUpdate,
           instruction.FpUpdate,
-          size(instruction)
         ],
       ];
     }
@@ -61,7 +59,7 @@ function DECODE_INSTRUCTION(encodedInstruction: string): [any[]] {
 }
 
 function TO_SIGNED_INTEGER(encodedInstruction: string): [any[]] {
-  return [["", "", toSignedInteger(BigInt(encodedInstruction))]];
+  return [["", "", toSignedInteger(BigInt(encodedInstruction)).toString(10)]];
 }
 
 /**

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -42,14 +42,25 @@ function showPicker() {
 function loadProgram(program: any) {
   programSheet.getRange("A2:G").clearContent();
   const bytecode: string[] = program.data;
-  programSheet
-    .getRange(`A2:B${bytecode.length + 1}`)
-    .setValues(
-      bytecode.map((instruction, i) => [
-        instruction,
-        `=IF(${progInstructionSizeColumn}${i + 2 - 1}=2;TO_SIGNED_INTEGER(A${i + 2});DECODE_INSTRUCTION(A${i + 2}))`,
-      ]),
-    );
+  let isConstant: boolean = false;
+  for (var i = 0; i < bytecode.length; i++) {
+    programSheet
+      .getRange(`A${i + 2}:B${i + 2}`)
+      .setValues([
+        [
+          bytecode[i],
+          isConstant
+            ? `=TO_SIGNED_INTEGER(A${i + 2})`
+            : `=DECODE_INSTRUCTION(A${i + 2})`,
+        ],
+      ]);
+    if (!isConstant) {
+      isConstant = size(decodeInstruction(BigInt(bytecode[i]))) == 2;
+    } else {
+      isConstant = false;
+    }
+  }
+
   runSheet.getRange("A1:O").clearContent();
   runSheet
     .getRange(`${pcColumn}1:${executionColumn}1`)

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -47,7 +47,7 @@ function loadProgram(program: any) {
     .setValues(
       bytecode.map((instruction, i) => [
         instruction,
-        `=DECODE_INSTRUCTION(A${i + 2})`,
+        `=IF(${progInstructionSizeColumn}${i + 2 - 1}=2;TO_SIGNED_INTEGER(A${i + 2});DECODE_INSTRUCTION(A${i + 2}))`,
       ]),
     );
   runSheet.getRange("A1:O").clearContent();

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -36,8 +36,6 @@ const progApupdateColumn: String = columns[j];
 j++;
 const progFpupdateColumn: String = columns[j];
 j++;
-const progInstructionSizeColumn: String = columns[j];
-j++;
 
 type Builtins = {
   output: BuitlinType;

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -36,6 +36,8 @@ const progApupdateColumn: String = columns[j];
 j++;
 const progFpupdateColumn: String = columns[j];
 j++;
+const progInstructionSizeColumn: String = columns[j];
+j++;
 
 type Builtins = {
   output: BuitlinType;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title -->

bug: decoding error with constants

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 45 mins

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently an instruction is interpreted as a felt constant as long as it is a NOp and has a regular PCUpdate.

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

Resolves #54 

## What is the new behavior?

There is no way to make a difference between a felt constant and an instruction.
So the new behavior is to try to decode all instructions and no matter if it fails or not, it will convert the instruction to a decimal number in the right column.
