### PR TITLE
add proof mode

### DIFF
--- a/cairo0/main_compiled_proof_mode.json
+++ b/cairo0/main_compiled_proof_mode.json
@@ -1,0 +1,1223 @@
+{
+  "attributes": [],
+  "builtins": ["range_check", "bitwise", "pedersen"],
+  "compiler_version": "0.13.1",
+  "data": [
+    "0x40780017fff7fff",
+    "0x3",
+    "0x1104800180018000",
+    "0x4",
+    "0x10780017fff7fff",
+    "0x0",
+    "0x480680017fff8000",
+    "0x4d2",
+    "0x400280007ffb7fff",
+    "0x400280007ffc7fff",
+    "0x480680017fff8000",
+    "0x10",
+    "0x400280017ffc7fff",
+    "0x480280027ffc8000",
+    "0x480280037ffc8000",
+    "0x480280047ffc8000",
+    "0x400280007ffd7ffb",
+    "0x480680017fff8000",
+    "0x10",
+    "0x400280017ffd7fff",
+    "0x480280027ffd8000",
+    "0x482680017ffb8000",
+    "0x1",
+    "0x482680017ffc8000",
+    "0x5",
+    "0x482680017ffd8000",
+    "0x3",
+    "0x208b7fff7fff7ffe"
+  ],
+  "debug_info": {
+    "file_contents": {
+      "<start>": "__start__:\nap += main.Args.SIZE + main.ImplicitArgs.SIZE;\ncall main;\n\n__end__:\njmp rel 0;\n"
+    },
+    "instruction_locations": {
+      "0": {
+        "accessible_scopes": ["__main__"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 0,
+            "offset": 0
+          },
+          "reference_ids": {}
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 46,
+          "end_line": 2,
+          "input_file": {
+            "filename": "<start>"
+          },
+          "start_col": 1,
+          "start_line": 2
+        }
+      },
+      "2": {
+        "accessible_scopes": ["__main__"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 0,
+            "offset": 3
+          },
+          "reference_ids": {}
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 10,
+          "end_line": 3,
+          "input_file": {
+            "filename": "<start>"
+          },
+          "start_col": 1,
+          "start_line": 3
+        }
+      },
+      "4": {
+        "accessible_scopes": ["__main__"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 1,
+            "offset": 0
+          },
+          "reference_ids": {}
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 10,
+          "end_line": 6,
+          "input_file": {
+            "filename": "<start>"
+          },
+          "start_col": 1,
+          "start_line": 6
+        }
+      },
+      "6": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 0
+          },
+          "reference_ids": {
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 0
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 23,
+          "end_line": 6,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 19,
+          "start_line": 6
+        }
+      },
+      "8": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 1
+          },
+          "reference_ids": {
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 0,
+            "__main__.main.res": 3
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 36,
+          "end_line": 7,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 7
+        }
+      },
+      "9": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 1
+          },
+          "reference_ids": {
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 32,
+          "end_line": 11,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 11
+        }
+      },
+      "10": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 1
+          },
+          "reference_ids": {
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 20,
+          "end_line": 10,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "parent_location": [
+            {
+              "end_col": 32,
+              "end_line": 12,
+              "input_file": {
+                "filename": "main.cairo"
+              },
+              "start_col": 28,
+              "start_line": 12
+            },
+            "While expanding the reference 'mask' in:"
+          ],
+          "start_col": 16,
+          "start_line": 10
+        }
+      },
+      "12": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 2
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 33,
+          "end_line": 12,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 12
+        }
+      },
+      "13": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 2
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 42,
+          "end_line": 13,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 23,
+          "start_line": 13
+        }
+      },
+      "14": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 3
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 42,
+          "end_line": 14,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 23,
+          "start_line": 14
+        }
+      },
+      "15": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 4
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 1,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 40,
+          "end_line": 15,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 22,
+          "start_line": 15
+        }
+      },
+      "16": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 5
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 33,
+          "end_line": 18,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 18
+        }
+      },
+      "17": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 5
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 20,
+          "end_line": 10,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "parent_location": [
+            {
+              "end_col": 33,
+              "end_line": 19,
+              "input_file": {
+                "filename": "main.cairo"
+              },
+              "start_col": 29,
+              "start_line": 19
+            },
+            "While expanding the reference 'mask' in:"
+          ],
+          "start_col": 16,
+          "start_line": 10
+        }
+      },
+      "19": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 6
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 34,
+          "end_line": 19,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 19
+        }
+      },
+      "20": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 6
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 2,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 39,
+          "end_line": 20,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 20,
+          "start_line": 20
+        }
+      },
+      "21": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 7
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.hash": 12,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 13,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 46,
+          "end_line": 8,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "parent_location": [
+            {
+              "end_col": 26,
+              "end_line": 5,
+              "input_file": {
+                "filename": "main.cairo"
+              },
+              "parent_location": [
+                {
+                  "end_col": 15,
+                  "end_line": 23,
+                  "input_file": {
+                    "filename": "main.cairo"
+                  },
+                  "start_col": 5,
+                  "start_line": 23
+                },
+                "While trying to retrieve the implicit argument 'range_check_ptr' in:"
+              ],
+              "start_col": 11,
+              "start_line": 5
+            },
+            "While expanding the reference 'range_check_ptr' in:"
+          ],
+          "start_col": 27,
+          "start_line": 8
+        }
+      },
+      "23": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 8
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.hash": 12,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 13,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 56,
+          "end_line": 16,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "parent_location": [
+            {
+              "end_col": 56,
+              "end_line": 5,
+              "input_file": {
+                "filename": "main.cairo"
+              },
+              "parent_location": [
+                {
+                  "end_col": 15,
+                  "end_line": 23,
+                  "input_file": {
+                    "filename": "main.cairo"
+                  },
+                  "start_col": 5,
+                  "start_line": 23
+                },
+                "While trying to retrieve the implicit argument 'bitwise_ptr' in:"
+              ],
+              "start_col": 28,
+              "start_line": 5
+            },
+            "While expanding the reference 'bitwise_ptr' in:"
+          ],
+          "start_col": 23,
+          "start_line": 16
+        }
+      },
+      "25": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 9
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.hash": 12,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 13,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 55,
+          "end_line": 21,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "parent_location": [
+            {
+              "end_col": 84,
+              "end_line": 5,
+              "input_file": {
+                "filename": "main.cairo"
+              },
+              "parent_location": [
+                {
+                  "end_col": 15,
+                  "end_line": 23,
+                  "input_file": {
+                    "filename": "main.cairo"
+                  },
+                  "start_col": 5,
+                  "start_line": 23
+                },
+                "While trying to retrieve the implicit argument 'pedersen_ptr' in:"
+              ],
+              "start_col": 58,
+              "start_line": 5
+            },
+            "While expanding the reference 'pedersen_ptr' in:"
+          ],
+          "start_col": 24,
+          "start_line": 21
+        }
+      },
+      "27": {
+        "accessible_scopes": ["__main__", "__main__.main"],
+        "flow_tracking_data": {
+          "ap_tracking": {
+            "group": 2,
+            "offset": 10
+          },
+          "reference_ids": {
+            "__main__.main.__temp0": 6,
+            "__main__.main.__temp1": 11,
+            "__main__.main.bitwise_ptr": 10,
+            "__main__.main.hash": 12,
+            "__main__.main.mask": 5,
+            "__main__.main.pedersen_ptr": 13,
+            "__main__.main.range_check_ptr": 4,
+            "__main__.main.res": 3,
+            "__main__.main.x_and_y": 7,
+            "__main__.main.x_or_y": 9,
+            "__main__.main.x_xor_y": 8
+          }
+        },
+        "hints": [],
+        "inst": {
+          "end_col": 15,
+          "end_line": 23,
+          "input_file": {
+            "filename": "main.cairo"
+          },
+          "start_col": 5,
+          "start_line": 23
+        }
+      }
+    }
+  },
+  "hints": {},
+  "identifiers": {
+    "__main__.BitwiseBuiltin": {
+      "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+      "type": "alias"
+    },
+    "__main__.HashBuiltin": {
+      "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+      "type": "alias"
+    },
+    "__main__.__end__": {
+      "pc": 4,
+      "type": "label"
+    },
+    "__main__.__start__": {
+      "pc": 0,
+      "type": "label"
+    },
+    "__main__.main": {
+      "decorators": [],
+      "pc": 6,
+      "type": "function"
+    },
+    "__main__.main.Args": {
+      "full_name": "__main__.main.Args",
+      "members": {},
+      "size": 0,
+      "type": "struct"
+    },
+    "__main__.main.ImplicitArgs": {
+      "full_name": "__main__.main.ImplicitArgs",
+      "members": {
+        "bitwise_ptr": {
+          "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+          "offset": 1
+        },
+        "pedersen_ptr": {
+          "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+          "offset": 2
+        },
+        "range_check_ptr": {
+          "cairo_type": "felt",
+          "offset": 0
+        }
+      },
+      "size": 3,
+      "type": "struct"
+    },
+    "__main__.main.Return": {
+      "cairo_type": "()",
+      "type": "type_definition"
+    },
+    "__main__.main.SIZEOF_LOCALS": {
+      "type": "const",
+      "value": 0
+    },
+    "__main__.main.__temp0": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.__temp0",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 2
+          },
+          "pc": 12,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.__temp1": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.__temp1",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 6
+          },
+          "pc": 19,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.bitwise_ptr": {
+      "cairo_type": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin*",
+      "full_name": "__main__.main.bitwise_ptr",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 0
+          },
+          "pc": 6,
+          "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 5
+          },
+          "pc": 16,
+          "value": "cast([fp + (-4)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.hash": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.hash",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 7
+          },
+          "pc": 21,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.mask": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.mask",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 1
+          },
+          "pc": 9,
+          "value": "cast(16, felt)"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.pedersen_ptr": {
+      "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+      "full_name": "__main__.main.pedersen_ptr",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 0
+          },
+          "pc": 6,
+          "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 7
+          },
+          "pc": 21,
+          "value": "cast([fp + (-3)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.range_check_ptr": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.range_check_ptr",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 0
+          },
+          "pc": 6,
+          "value": "[cast(fp + (-5), felt*)]"
+        },
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 1
+          },
+          "pc": 9,
+          "value": "cast([fp + (-5)] + 1, felt)"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.res": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.res",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 1
+          },
+          "pc": 8,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.x_and_y": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.x_and_y",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 3
+          },
+          "pc": 14,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.x_or_y": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.x_or_y",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 5
+          },
+          "pc": 16,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "__main__.main.x_xor_y": {
+      "cairo_type": "felt",
+      "full_name": "__main__.main.x_xor_y",
+      "references": [
+        {
+          "ap_tracking_data": {
+            "group": 2,
+            "offset": 4
+          },
+          "pc": 15,
+          "value": "[cast(ap + (-1), felt*)]"
+        }
+      ],
+      "type": "reference"
+    },
+    "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+      "members": {
+        "x": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "x_and_y": {
+          "cairo_type": "felt",
+          "offset": 2
+        },
+        "x_or_y": {
+          "cairo_type": "felt",
+          "offset": 4
+        },
+        "x_xor_y": {
+          "cairo_type": "felt",
+          "offset": 3
+        },
+        "y": {
+          "cairo_type": "felt",
+          "offset": 1
+        }
+      },
+      "size": 5,
+      "type": "struct"
+    },
+    "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+      "members": {
+        "m": {
+          "cairo_type": "felt",
+          "offset": 4
+        },
+        "p": {
+          "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+          "offset": 0
+        },
+        "q": {
+          "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+          "offset": 2
+        },
+        "r": {
+          "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+          "offset": 5
+        }
+      },
+      "size": 7,
+      "type": "struct"
+    },
+    "starkware.cairo.common.cairo_builtins.EcPoint": {
+      "destination": "starkware.cairo.common.ec_point.EcPoint",
+      "type": "alias"
+    },
+    "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+      "members": {
+        "result": {
+          "cairo_type": "felt",
+          "offset": 2
+        },
+        "x": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "y": {
+          "cairo_type": "felt",
+          "offset": 1
+        }
+      },
+      "size": 3,
+      "type": "struct"
+    },
+    "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+      "members": {
+        "input": {
+          "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+          "offset": 0
+        },
+        "output": {
+          "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+          "offset": 8
+        }
+      },
+      "size": 16,
+      "type": "struct"
+    },
+    "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+      "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+      "type": "alias"
+    },
+    "starkware.cairo.common.cairo_builtins.PoseidonBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.PoseidonBuiltin",
+      "members": {
+        "input": {
+          "cairo_type": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+          "offset": 0
+        },
+        "output": {
+          "cairo_type": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+          "offset": 3
+        }
+      },
+      "size": 6,
+      "type": "struct"
+    },
+    "starkware.cairo.common.cairo_builtins.PoseidonBuiltinState": {
+      "destination": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+      "type": "alias"
+    },
+    "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+      "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+      "members": {
+        "message": {
+          "cairo_type": "felt",
+          "offset": 1
+        },
+        "pub_key": {
+          "cairo_type": "felt",
+          "offset": 0
+        }
+      },
+      "size": 2,
+      "type": "struct"
+    },
+    "starkware.cairo.common.ec_point.EcPoint": {
+      "full_name": "starkware.cairo.common.ec_point.EcPoint",
+      "members": {
+        "x": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "y": {
+          "cairo_type": "felt",
+          "offset": 1
+        }
+      },
+      "size": 2,
+      "type": "struct"
+    },
+    "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+      "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+      "members": {
+        "s0": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "s1": {
+          "cairo_type": "felt",
+          "offset": 1
+        },
+        "s2": {
+          "cairo_type": "felt",
+          "offset": 2
+        },
+        "s3": {
+          "cairo_type": "felt",
+          "offset": 3
+        },
+        "s4": {
+          "cairo_type": "felt",
+          "offset": 4
+        },
+        "s5": {
+          "cairo_type": "felt",
+          "offset": 5
+        },
+        "s6": {
+          "cairo_type": "felt",
+          "offset": 6
+        },
+        "s7": {
+          "cairo_type": "felt",
+          "offset": 7
+        }
+      },
+      "size": 8,
+      "type": "struct"
+    },
+    "starkware.cairo.common.poseidon_state.PoseidonBuiltinState": {
+      "full_name": "starkware.cairo.common.poseidon_state.PoseidonBuiltinState",
+      "members": {
+        "s0": {
+          "cairo_type": "felt",
+          "offset": 0
+        },
+        "s1": {
+          "cairo_type": "felt",
+          "offset": 1
+        },
+        "s2": {
+          "cairo_type": "felt",
+          "offset": 2
+        }
+      },
+      "size": 3,
+      "type": "struct"
+    }
+  },
+  "main_scope": "__main__",
+  "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+  "reference_manager": {
+    "references": [
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 0
+        },
+        "pc": 6,
+        "value": "[cast(fp + (-5), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 0
+        },
+        "pc": 6,
+        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.BitwiseBuiltin**)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 0
+        },
+        "pc": 6,
+        "value": "[cast(fp + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 1
+        },
+        "pc": 8,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 1
+        },
+        "pc": 9,
+        "value": "cast([fp + (-5)] + 1, felt)"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 1
+        },
+        "pc": 9,
+        "value": "cast(16, felt)"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 2
+        },
+        "pc": 12,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 3
+        },
+        "pc": 14,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 4
+        },
+        "pc": 15,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 5
+        },
+        "pc": 16,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 5
+        },
+        "pc": 16,
+        "value": "cast([fp + (-4)] + 5, starkware.cairo.common.cairo_builtins.BitwiseBuiltin*)"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 6
+        },
+        "pc": 19,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 7
+        },
+        "pc": 21,
+        "value": "[cast(ap + (-1), felt*)]"
+      },
+      {
+        "ap_tracking_data": {
+          "group": 2,
+          "offset": 7
+        },
+        "pc": 21,
+        "value": "cast([fp + (-3)] + 3, starkware.cairo.common.cairo_builtins.HashBuiltin*)"
+      }
+    ]
+  }
+}

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -184,15 +184,9 @@ function GET_FLAGS_AND_OFFSETS(encodedInstruction: string): number[][] {
     BigInt(encodedInstruction),
   );
 
-  let traceFlags: number[] = [];
-
-  for (let i = 0; i <= 15; i++) {
-    let sum = 0;
-    for (let j = i; j <= 14; j++) {
-      sum += 2 ** (j - i) * flags[i];
-    }
-    traceFlags.push(sum);
-  }
+  let traceFlags: number[] = flags.map((f, i, arr) =>
+    parseInt(arr.slice(i).join()),
+  );
 
   return [[dstOffset, op0Offset, op1Offset, ...traceFlags]];
 }

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -185,7 +185,7 @@ function GET_FLAGS_AND_OFFSETS(encodedInstruction: string): number[][] {
   );
 
   let traceFlags: number[] = flags.map((f, i, arr) =>
-    parseInt(arr.slice(i).reverse().join()),
+    parseInt(arr.slice(i).reverse().join(""), 2),
   );
 
   return [[dstOffset, op0Offset, op1Offset, ...traceFlags]];

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -185,7 +185,7 @@ function GET_FLAGS_AND_OFFSETS(encodedInstruction: string): number[][] {
   );
 
   let traceFlags: number[] = flags.map((f, i, arr) =>
-    parseInt(arr.slice(i).join()),
+    parseInt(arr.slice(i).reverse().join()),
   );
 
   return [[dstOffset, op0Offset, op1Offset, ...traceFlags]];

--- a/src/ui/Code.ts
+++ b/src/ui/Code.ts
@@ -178,3 +178,21 @@ function ADD_FELT(a: number | string, b: number | string): number | string {
 function MUL_FELT(a: number | string, b: number | string): number | string {
   return modMul(BigInt(a), BigInt(b)).toString(10);
 }
+
+function GET_FLAGS_AND_OFFSETS(encodedInstruction: string): number[][] {
+  const { dstOffset, op0Offset, op1Offset, flags } = getTraceInfo(
+    BigInt(encodedInstruction),
+  );
+
+  let traceFlags: number[] = [];
+
+  for (let i = 0; i <= 15; i++) {
+    let sum = 0;
+    for (let j = i; j <= 14; j++) {
+      sum += 2 ** (j - i) * flags[i];
+    }
+    traceFlags.push(sum);
+  }
+
+  return [[dstOffset, op0Offset, op1Offset, ...traceFlags]];
+}

--- a/src/ui/dialog.html
+++ b/src/ui/dialog.html
@@ -63,7 +63,17 @@
         <p>Pick a layout :</p>
         <select id="layoutPicker">
           <option value="plain">Plain</option>
+          <option value="small">Small</option>
+          <option value="dex">Dex</option>
           <option value="recursive">Recursive</option>
+          <option value="starknet_with_keccak">Starknet with Keccak</option>
+          <option value="recursive_large_output">Recursive large output</option>
+          <option value="recursive_with_poseidon">
+            Recursive with Poseidon
+          </option>
+          <option value="all_cairo">All Cairo</option>
+          <option value="all_solidity">All Solidity</option>
+          <option value="dynamic">Dynamic</option>
         </select>
       </div>
     </div>

--- a/src/ui/dialog.html
+++ b/src/ui/dialog.html
@@ -9,18 +9,29 @@
       function closeDialog() {
         google.script.host.close();
       }
+
       function onFileLoad(event) {
         var compiledJson = JSON.parse(event.target.result);
+        var selectedRunnerMode = document.querySelector(
+          'input[name="runnerMode"]:checked',
+        ).value;
+        var selectedLayout = document.getElementById("layoutPicker").value;
         google.script.run
           .withSuccessHandler(closeDialog)
           .withFailureHandler(closeDialog)
-          .loadProgram(compiledJson);
+          .loadProgram(
+            JSON.stringify(compiledJson, null, 2),
+            selectedRunnerMode,
+            selectedLayout,
+          );
       }
+
       function onFileChange(event) {
         var fileReader = new FileReader();
         fileReader.onload = onFileLoad;
         fileReader.readAsText(event.target.files[0]);
       }
+
       function onApiLoad() {
         document
           .getElementById("program")
@@ -31,7 +42,32 @@
   <body>
     <div>
       <input id="program" type="file" accept="application/json" />
+
+      <div>
+        <p>Select the runner configuration :</p>
+        <label
+          ><input
+            type="radio"
+            name="runnerMode"
+            value="execution"
+            checked
+          />Execution mode</label
+        ><br />
+        <label
+          ><input type="radio" name="runnerMode" value="proof" />Proof
+          mode</label
+        ><br />
+      </div>
+
+      <div>
+        <p>Pick a layout :</p>
+        <select id="layoutPicker">
+          <option value="plain">Plain</option>
+          <option value="recursive">Recursive</option>
+        </select>
+      </div>
     </div>
+
     <script src="https://apis.google.com/js/api.js?onload=onApiLoad"></script>
   </body>
 </html>

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -72,7 +72,9 @@ function loadProgram(program: any) {
   runSheet.getRange("A1:O").clearContent();
   runSheet
     .getRange(`${pcColumn}1:${executionColumn}1`)
-    .setValues([["PC", "FP", "AP", "Opcode", "Dst", "Src", "Execution"]]);
+    .setValues([
+      ["PC", "FP", "AP", "Opcode", "Dst", "Res", "Op0", "Op1", "Execution"],
+    ]);
   const builtinsList: string[] = program.builtins;
   const segmentAddresses: string[] = initializeSegments(builtinsList);
   const mainOffset: string | number =

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -28,7 +28,12 @@ function clear(): void {
     .clearContent();
   runSheet
     .getRange(
-      `${firstBuiltinColumn}2:${columns[letterToIndex(firstBuiltinColumn) + stackLength + 2]}`,
+      `${firstBuiltinColumn}2:${indexToColumn(columnToIndex(firstBuiltinColumn) + stackLength + 2)}`,
+    )
+    .clearContent();
+  proverSheet
+    .getRange(
+      `${provSegmentsColumn}3:${indexToColumn(getLastActiveColumnNumber(2, proverSheet) - 1)}`,
     )
     .clearContent();
 }
@@ -47,8 +52,18 @@ function showPicker() {
 }
 
 function loadProgram(program: any) {
-  programSheet.getRange(`${progBytecodeColumn}2:AA`).clearContent();
-  proverSheet.getRange(`${provSegmentsColumn}3:Q`).clearContent();
+  proverSheet
+    .getRange(
+      `${provSegmentsColumn}3:${indexToColumn(getLastActiveColumnNumber(2, proverSheet) - 1)}`,
+    )
+    .clearContent();
+
+  //Program sheet
+  programSheet
+    .getRange(
+      `${progBytecodeColumn}2:${indexToColumn(getLastActiveColumnNumber(1, programSheet) - 1)}`,
+    )
+    .clearContent();
 
   programSheet
     .getRange(`${progDecInstructionColumn}1`)
@@ -56,14 +71,13 @@ function loadProgram(program: any) {
   programSheet
     .getRange(`${progDstOffsetColumn}1:${progOp1OffsetColumn}1`)
     .setValues([["Dst Offset", "Op0 Offset", "Op1 Offset"]]);
-  for (let flagIndex = 0; flagIndex < 15; flagIndex++) {
+  for (let flagIndex = 0; flagIndex < 16; flagIndex++) {
     programSheet
       .getRange(
-        `${columns[letterToIndex(progOp1OffsetColumn) + flagIndex + 1]}1`,
+        `${indexToColumn(columnToIndex(progOp1OffsetColumn) + flagIndex + 1)}1`,
       )
       .setValue(`f_${flagIndex}`);
   }
-  programSheet.getRange(`AA1`).setValue(`f_15`);
 
   const bytecode: string[] = program.data;
   let isConstant: boolean = false;
@@ -91,7 +105,12 @@ function loadProgram(program: any) {
     }
   }
 
-  runSheet.getRange("A1:Q").clearContent();
+  //Run sheet
+  runSheet
+    .getRange(
+      `${pcColumn}1:${indexToColumn(getLastActiveColumnNumber(1, runSheet) - 1)}`,
+    )
+    .clearContent();
   runSheet
     .getRange(`${pcColumn}1:${executionColumn}1`)
     .setValues([
@@ -112,7 +131,11 @@ function loadProgram(program: any) {
 }
 
 function relocate() {
-  proverSheet.getRange(`${provSegmentsColumn}3:${columns[k]}`).clearContent();
+  proverSheet
+    .getRange(
+      `${provSegmentsColumn}3:${indexToColumn(getLastActiveColumnNumber(2, proverSheet) - 1)}`,
+    )
+    .clearContent();
 
   proverSheet.getRange(`${provSegmentsColumn}1`).setValue("Memory");
   proverSheet

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -62,6 +62,12 @@ function loadProgram(program: any) {
       isConstant = false;
     }
   }
+  programSheet.getRange("H1").setValue("Decimal instruction");
+  programSheet
+    .getRange(`H2:H${getLastActiveRowNumber("A", programSheet)}`)
+    .setValues(
+      bytecode.map((instruction) => [BigInt(instruction).toString(10)]),
+    );
 
   runSheet.getRange("A1:O").clearContent();
   runSheet

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -16,12 +16,19 @@ function menuStep(): void {
 function menuRun(): void {
   let lastStepNumber: number = runUntilPc();
   if (isProofMode()) {
+    step(lastStepNumber - 1);
+    let equalToLastStepFormulas: string[] = [];
+    for (let i = 0; i <= columnToIndex(runOp1Column); i++) {
+      equalToLastStepFormulas.push(`=${indexToColumn(i)}${lastStepNumber + 1}`);
+    }
     for (
-      let stepNum = lastStepNumber;
-      stepNum <= nextPowerOfTwo(lastStepNumber);
+      let stepNum = lastStepNumber + 2;
+      stepNum <= nextPowerOfTwo(lastStepNumber) + 1;
       stepNum++
     ) {
-      step(stepNum - 1);
+      runSheet
+        .getRange(`${pcColumn}${stepNum}:${runOp1Column}${stepNum}`)
+        .setFormulas([equalToLastStepFormulas]);
     }
   }
 }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -17,12 +17,31 @@ function menuRun(): void {
   let lastStepNumber: number = runUntilPc();
   if (isProofMode()) {
     step(lastStepNumber - 1);
+    step(lastStepNumber - 1 + 1);
+    let lastRegisters = runSheet
+      .getRange(
+        `${pcColumn}${lastStepNumber + 1}:${apColumn}${lastStepNumber + 1}`,
+      )
+      .getValues();
+    let firstOfLoopRegister = runSheet
+      .getRange(
+        `${pcColumn}${lastStepNumber + 2}:${apColumn}${lastStepNumber + 2}`,
+      )
+      .getValues();
+    if (
+      Number(lastRegisters[0][0]) != Number(firstOfLoopRegister[0][0]) &&
+      Number(lastRegisters[0][1]) != Number(firstOfLoopRegister[0][1]) &&
+      Number(lastRegisters[0][2]) != Number(firstOfLoopRegister[0][2])
+    ) {
+      Logger.log("Make sure the program is compiled and loaded in proof mode.");
+      throw new InvalidLoopRegisters();
+    }
     let equalToLastStepFormulas: string[] = [];
     for (let i = 0; i <= columnToIndex(runOp1Column); i++) {
-      equalToLastStepFormulas.push(`=${indexToColumn(i)}${lastStepNumber + 1}`);
+      equalToLastStepFormulas.push(`=${indexToColumn(i)}${lastStepNumber + 2}`);
     }
     for (
-      let stepNum = lastStepNumber + 2;
+      let stepNum = lastStepNumber + 3;
       stepNum <= nextPowerOfTwo(lastStepNumber) + 1;
       stepNum++
     ) {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -36,19 +36,21 @@ function menuRun(): void {
       Logger.log("Make sure the program is compiled and loaded in proof mode.");
       throw new InvalidLoopRegisters();
     }
-    let equalToLastStepFormulas: string[] = [];
-    for (let i = 0; i <= columnToIndex(runOp1Column); i++) {
-      equalToLastStepFormulas.push(`=${indexToColumn(i)}${lastStepNumber + 2}`);
-    }
     for (
       let stepNum = lastStepNumber + 3;
       stepNum <= nextPowerOfTwo(lastStepNumber) + 1;
       stepNum++
     ) {
-      runSheet
-        .getRange(`${pcColumn}${stepNum}:${runOp1Column}${stepNum}`)
-        .setFormulas([equalToLastStepFormulas]);
+      step(stepNum - 2);
     }
+
+    //Clear new registers for proper relocation purposes
+    let registerRowToClear: number = nextPowerOfTwo(lastStepNumber) + 2;
+    runSheet
+      .getRange(
+        `${pcColumn}${registerRowToClear}:${apColumn}${registerRowToClear}`,
+      )
+      .clearContent();
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,3 +143,15 @@ function isFinalPc(pc: number | string): boolean {
     .indexOf(FINAL_PC);
   return finalPcColumnIndex == letterToIndex(pc.toString()[0]);
 }
+
+function bigintTo15BitString(value: bigint): string {
+  let binaryStr = value.toString(2);
+
+  if (binaryStr.length > 15) {
+    binaryStr = binaryStr.slice(-15);
+  } else {
+    binaryStr = binaryStr.padStart(15, "0");
+  }
+
+  return binaryStr;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -148,11 +148,7 @@ function updateBuiltins() {
 }
 
 function isFinalPc(pc: number | string): boolean {
-  const finalPcColumnIndex: number = runSheet
-    .getRange("1:1")
-    .getValues()[0]
-    .indexOf(FINAL_PC);
-  return finalPcColumnIndex == columnToIndex(pc.toString()[0]);
+  return pc == programSheet.getRange(getFinalPcCell()).getValue();
 }
 
 function bigintTo15BitString(value: bigint): string {
@@ -185,4 +181,40 @@ function columnToIndex(column: string): number {
     rowNum += column.charCodeAt(i) - 64;
   }
   return rowNum - 1;
+}
+
+function getFinalPcCell(): string {
+  return `B${
+    programSheet
+      .getRange("A1:A")
+      .getValues()
+      .map((value) => {
+        if (value) {
+          return value[0];
+        }
+      })
+      .indexOf(FINAL_PC) + 1
+  }`;
+}
+
+function getProofModeCell(): string {
+  return `B${
+    programSheet
+      .getRange("A1:A")
+      .getValues()
+      .map((value) => {
+        if (value) {
+          return value[0];
+        }
+      })
+      .indexOf("proof_mode") + 1
+  }`;
+}
+
+function isProofMode(): boolean {
+  return Number(programSheet.getRange(getProofModeCell()).getValue()) == 1;
+}
+
+function nextPowerOfTwo(n: number): number {
+  return 1 << Math.ceil(Math.log2(n));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,21 @@ function getLastActiveFormulaRowNumber(column: string, sheet): number {
   return columnValues.length - lastNonEmptyIndex;
 }
 
+function getLastActiveColumnNumber(row: number, sheet): number {
+  let rowValues: string[] = sheet.getRange(`${row}1:${row}`).getValues()[0];
+
+  let lastNonEmptyIndex = rowValues
+    .slice()
+    .reverse()
+    .findIndex((value) => value !== "");
+
+  if (lastNonEmptyIndex === -1) {
+    return 0;
+  }
+
+  return rowValues.length - lastNonEmptyIndex;
+}
+
 function encodeUTF8(str: string): Uint8Array {
   const utf8Bytes: number[] = [];
 
@@ -132,16 +147,12 @@ function updateBuiltins() {
   }
 }
 
-function letterToIndex(char: string | String): number {
-  return char.charCodeAt(0) - "A".charCodeAt(0);
-}
-
 function isFinalPc(pc: number | string): boolean {
   const finalPcColumnIndex: number = runSheet
     .getRange("1:1")
     .getValues()[0]
     .indexOf(FINAL_PC);
-  return finalPcColumnIndex == letterToIndex(pc.toString()[0]);
+  return finalPcColumnIndex == columnToIndex(pc.toString()[0]);
 }
 
 function bigintTo15BitString(value: bigint): string {
@@ -154,4 +165,24 @@ function bigintTo15BitString(value: bigint): string {
   }
 
   return binaryStr;
+}
+
+function indexToColumn(index: number): string {
+  let column = "";
+  index += 1;
+  while (index > 0) {
+    let remainder = (index - 1) % 26;
+    column = String.fromCharCode(65 + remainder) + column;
+    index = Math.floor((index - 1) / 26);
+  }
+  return column;
+}
+
+function columnToIndex(column: string): number {
+  let rowNum = 0;
+  for (let i = 0; i < column.length; i++) {
+    rowNum *= 26;
+    rowNum += column.charCodeAt(i) - 64;
+  }
+  return rowNum - 1;
 }

--- a/src/vm/constants.ts
+++ b/src/vm/constants.ts
@@ -68,6 +68,10 @@ interface BuitlinType {
   functionName: string[];
 }
 
+type Layout = {
+  builtins: string[];
+};
+
 const PRIME: bigint = BigInt(
   "0x800000000000011000000000000000000000000000000000000000000000001",
 );
@@ -131,3 +135,80 @@ const FpUpdates: FpUpdatesType = {
 
 const FINAL_FP: string = "final_fp";
 const FINAL_PC: string = "final_pc";
+
+const layouts: { [key: string]: Layout } = {
+  plain: {
+    builtins: [],
+  },
+  small: {
+    builtins: ["output", "pedersen", "range_check", "ecdsa"],
+  },
+  dex: {
+    builtins: ["output", "pedersen", "range_check", "ecdsa"],
+  },
+  recursive: {
+    builtins: ["output", "pedersen", "range_check", "bitwise"],
+  },
+  starknet: {
+    builtins: [
+      "output",
+      "pedersen",
+      "range_check",
+      "ecdsa",
+      "bitwise",
+      "ec_op",
+      "poseidon",
+    ],
+  },
+  starknet_with_keccak: {
+    builtins: [
+      "output",
+      "pedersen",
+      "range_check",
+      "ecdsa",
+      "bitwise",
+      "ec_op",
+      "keccak",
+      "poseidon",
+    ],
+  },
+  recursive_large_output: {
+    builtins: ["output", "pedersen", "range_check", "bitwise", "poseidon"],
+  },
+  recursive_with_poseidon: {
+    builtins: ["output", "pedersen", "range_check", "bitwise", "poseidon"],
+  },
+  all_cairo: {
+    builtins: [
+      "output",
+      "pedersen",
+      "range_check",
+      "ecdsa",
+      "bitwise",
+      "ec_op",
+      "keccak",
+      "poseidon",
+      "range_check96",
+    ],
+  },
+  all_solidity: {
+    builtins: [
+      "output",
+      "pedersen",
+      "range_check",
+      "ecdsa",
+      "bitwise",
+      "ec_op",
+    ],
+  },
+  dynamic: {
+    builtins: [
+      "output",
+      "pedersen",
+      "range_check",
+      "ecdsa",
+      "bitwise",
+      "ec_op",
+    ],
+  },
+};

--- a/src/vm/errors.ts
+++ b/src/vm/errors.ts
@@ -9,3 +9,4 @@ class InvalidDstRegisterError extends Error {}
 class InvalidRangeError extends Error {}
 class AssertEqError extends Error {}
 class InvalidCellSumError extends Error {}
+class InvalidLoopRegisters extends Error {}

--- a/src/vm/instructions.ts
+++ b/src/vm/instructions.ts
@@ -12,6 +12,13 @@ interface decodedInstruction {
   FpUpdate: string;
 }
 
+interface traceInfo {
+  dstOffset: number;
+  op0Offset: number;
+  op1Offset: number;
+  flags: number[];
+}
+
 function fromBiasedRepresentation(offset: bigint): number {
   const bias: bigint = BigInt(1) << BigInt(15);
   return Number(BigInt(Number(offset)) - bias);
@@ -53,7 +60,7 @@ function decodeInstruction(encodedInstruction: bigint): decodedInstruction {
   const op0Offset: number = this.fromBiasedRepresentation(
     (encodedInstruction >> BigInt(16)) & BigInt(0xffff),
   );
-  let op1Offset: number = this.fromBiasedRepresentation(
+  const op1Offset: number = this.fromBiasedRepresentation(
     (encodedInstruction >> BigInt(32)) & BigInt(0xffff),
   );
 
@@ -211,4 +218,22 @@ function decodeInstruction(encodedInstruction: bigint): decodedInstruction {
     ApUpdate: apUpdate,
     FpUpdate: fpUpdate,
   };
+}
+
+function getTraceInfo(encodedInstruction: bigint): traceInfo {
+  const dstOffset: number = Number(encodedInstruction & BigInt(0xffff));
+  const op0Offset: number = Number(
+    (encodedInstruction >> BigInt(16)) & BigInt(0xffff),
+  );
+  const op1Offset: number = Number(
+    (encodedInstruction >> BigInt(32)) & BigInt(0xffff),
+  );
+
+  let flagsBigint: bigint = encodedInstruction >> BigInt(48);
+  let flags: number[] = bigintTo15BitString(flagsBigint)
+    .split("")
+    .map((flag) => Number(flag))
+    .reverse();
+
+  return { dstOffset, op0Offset, op1Offset, flags };
 }

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -8,65 +8,69 @@ const programSheet: GoogleAppsScript.Spreadsheet.Sheet =
 const columns: String[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 
 let i = 0;
-const pcColumn: String = columns[i];
+const pcColumn: string = indexToColumn(i);
 i++;
-const fpColumn: String = columns[i];
+const fpColumn: string = indexToColumn(i);
 i++;
-const apColumn: String = columns[i];
+const apColumn: string = indexToColumn(i);
 i++;
-const opcodeColumn: String = columns[i];
+const opcodeColumn: string = indexToColumn(i);
 i++;
-const dstColumn: String = columns[i];
+const dstColumn: string = indexToColumn(i);
 i++;
-const resColumn: String = columns[i];
+const resColumn: string = indexToColumn(i);
 i++;
-const op0Column: String = columns[i];
+const op0Column: string = indexToColumn(i);
 i++;
-const runOp1Column: String = columns[i];
+const runOp1Column: string = indexToColumn(i);
 i++;
-const executionColumn: String = columns[i];
+const executionColumn: string = indexToColumn(i);
 i++;
-const firstBuiltinColumn: String = columns[i];
+const firstBuiltinColumn: string = indexToColumn(i);
 i++;
 
 let j = 0;
-const progBytecodeColumn: String = columns[j];
+const progBytecodeColumn: string = indexToColumn(j);
 j++;
-const progOpcodeColumn: String = columns[j];
+const progOpcodeColumn: string = indexToColumn(j);
 j++;
-const progDstColumn: String = columns[j];
+const progDstColumn: string = indexToColumn(j);
 j++;
-const progOpColumn: String = columns[j];
+const progOpColumn: string = indexToColumn(j);
 j++;
-const progPcupdateColumn: String = columns[j];
+const progPcupdateColumn: string = indexToColumn(j);
 j++;
-const progApupdateColumn: String = columns[j];
+const progApupdateColumn: string = indexToColumn(j);
 j++;
-const progFpupdateColumn: String = columns[j];
+const progFpupdateColumn: string = indexToColumn(j);
 j++;
-const progDecInstructionColumn: String = columns[j];
+const progDecInstructionColumn: string = indexToColumn(j);
 j++;
-const progDstOffsetColumn: String = columns[j];
+const progDstOffsetColumn: string = indexToColumn(j);
 j++;
-const progOp0OffsetColumn: String = columns[j];
+const progOp0OffsetColumn: string = indexToColumn(j);
 j++;
-const progOp1OffsetColumn: String = columns[j];
+const progOp1OffsetColumn: string = indexToColumn(j);
+j++;
+const progFlag0Column: string = indexToColumn(j);
+j += 15;
+const progFlag15Column: string = indexToColumn(j);
 j++;
 
 let k = 0;
-const provSegmentsColumn: String = columns[k];
+const provSegmentsColumn: string = indexToColumn(k);
 k++;
-const provAddressColumn: String = columns[k];
+const provAddressColumn: string = indexToColumn(k);
 k++;
-const provValuesColumn: String = columns[k];
+const provValuesColumn: string = indexToColumn(k);
 k++;
-const provMemoryRelocatedColumn: String = columns[k];
+const provMemoryRelocatedColumn: string = indexToColumn(k);
 k++;
-const provRelocatedPcColumn: String = columns[k];
+const provRelocatedPcColumn: string = indexToColumn(k);
 k++;
-const provRelocatedFpColumn: String = columns[k];
+const provRelocatedFpColumn: string = indexToColumn(k);
 k++;
-const provRelocatedApColumn: String = columns[k];
+const provRelocatedApColumn: string = indexToColumn(k);
 k++;
 
 type Builtins = {
@@ -114,21 +118,19 @@ let builtins: Builtins = {
 let builtinsColumns: {};
 function initializeSegments(builtinsList: string[]): string[] {
   let counter: number = 0;
-  const executionColumnOffset: number = columns.indexOf(executionColumn) + 1;
+  const executionColumnOffset: number = columnToIndex(executionColumn) + 1;
 
   for (var key of builtinsList) {
-    builtins[key].column = columns[counter + executionColumnOffset];
+    builtins[key].column = indexToColumn(counter + executionColumnOffset);
     counter++;
   }
 
-  let fpRow: String =
-    columns[
-      letterToIndex(builtins[builtinsList[builtinsList.length - 1]].column) + 1
-    ];
-  let pcRow: String =
-    columns[
-      letterToIndex(builtins[builtinsList[builtinsList.length - 1]].column) + 2
-    ];
+  let fpRow: string = indexToColumn(
+    columnToIndex(builtins[builtinsList[builtinsList.length - 1]].column) + 1,
+  );
+  let pcRow: string = indexToColumn(
+    columnToIndex(builtins[builtinsList[builtinsList.length - 1]].column) + 2,
+  );
   runSheet
     .getRange(`${builtins[builtinsList[0]].column}1:${pcRow}1`)
     .setValues([[...builtinsList, FINAL_FP, FINAL_PC]]);
@@ -507,13 +509,13 @@ function runUntilPc(): void {
 
 function relocateMemory() {
   let formulas: string[] = [];
-  let columnIndex: number = letterToIndex(executionColumn);
+  let columnIndex: number = columnToIndex(executionColumn);
   let maxProgramRow: number = getLastActiveRowNumber("A", programSheet);
   for (let row = 2; row <= maxProgramRow; row++) {
     formulas.push(`=Program!H${row}`);
   }
   while (runSheet.getRange(1, columnIndex + 1).getValue() != "") {
-    let currentColumn: string = columns[columnIndex].toString();
+    let currentColumn: string = indexToColumn(columnIndex);
     let maxRowNumber: number = getLastActiveRowNumber(currentColumn, runSheet);
     let extraCell: number = currentColumn == executionColumn ? 0 : 1;
     for (let row = 2; row <= maxRowNumber + extraCell; row++) {
@@ -522,11 +524,11 @@ function relocateMemory() {
     columnIndex++;
   }
   proverSheet
-    .getRange(3, letterToIndex(provValuesColumn) + 1, formulas.length)
+    .getRange(3, columnToIndex(provValuesColumn) + 1, formulas.length)
     .setFormulas(formulas.map((formula) => [formula]));
 
   proverSheet
-    .getRange(3, letterToIndex(provSegmentsColumn) + 1, formulas.length)
+    .getRange(3, columnToIndex(provSegmentsColumn) + 1, formulas.length)
     .setFormulas(
       formulas.map((_, index) => [
         `=FORMULATEXT(${provValuesColumn}${index + 3})`,
@@ -534,7 +536,7 @@ function relocateMemory() {
     );
 
   proverSheet
-    .getRange(3, letterToIndex(provAddressColumn) + 1, formulas.length)
+    .getRange(3, columnToIndex(provAddressColumn) + 1, formulas.length)
     .setFormulas(
       formulas.map((_, index) => [
         `=REGEXEXTRACT(${provSegmentsColumn}${index + 3}; "([A-Z]+[0-9]+)$")`,
@@ -542,7 +544,7 @@ function relocateMemory() {
     );
 
   proverSheet
-    .getRange(3, letterToIndex(provMemoryRelocatedColumn) + 1, formulas.length)
+    .getRange(3, columnToIndex(provMemoryRelocatedColumn) + 1, formulas.length)
     .setFormulas(
       formulas.map((_, index) => [
         `=IFERROR(MATCH(${provValuesColumn}${index + 3};${provAddressColumn}3:${provAddressColumn}); ${provValuesColumn}${index + 3})`,

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -20,6 +20,10 @@ const dstColumn: String = columns[i];
 i++;
 const resColumn: String = columns[i];
 i++;
+const op0Column: String = columns[i];
+i++;
+const runOp1Column: String = columns[i];
+i++;
 const executionColumn: String = columns[i];
 i++;
 
@@ -387,6 +391,9 @@ function step(n: number = 0): void {
       }
       break;
   }
+
+  runSheet.getRange(`${op0Column}${n + 2}`).setFormula(`=${op0Addr}`);
+  runSheet.getRange(`${runOp1Column}${n + 2}`).setFormula(`=${op1Addr}`);
 
   const resValue: string = runSheet.getRange(`${resColumn}${n + 2}`).getValue();
 

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -557,13 +557,20 @@ function runUntilPc(): number {
 function relocateMemory() {
   let formulas: string[] = [];
   let columnIndex: number = columnToIndex(executionColumn);
-  let maxProgramRow: number = getLastActiveRowNumber("C", programSheet);
+  let maxProgramRow: number = getLastActiveRowNumber(
+    progDecInstructionColumn,
+    programSheet,
+  );
   for (let row = 2; row <= maxProgramRow; row++) {
-    formulas.push(`=Program!H${row}`);
+    formulas.push(`=Program!${progDecInstructionColumn}${row}`);
   }
   while (runSheet.getRange(1, columnIndex + 1).getValue() != "") {
     let currentColumn: string = indexToColumn(columnIndex);
     let maxRowNumber: number = getLastActiveRowNumber(currentColumn, runSheet);
+    if (maxRowNumber == 1) {
+      columnIndex++;
+      continue;
+    }
     let extraCell: number = currentColumn == executionColumn ? 0 : 1;
     for (let row = 2; row <= maxRowNumber + extraCell; row++) {
       formulas.push(`=Run!${currentColumn}${row}`);

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -491,6 +491,10 @@ function runUntilPc(): void {
 function relocateMemory() {
   let formulas: string[] = [];
   let columnIndex: number = letterToIndex(executionColumn);
+  let maxProgramRow: number = getLastActiveRowNumber("A", programSheet);
+  for (let row = 2; row <= maxProgramRow; row++) {
+    formulas.push(`=Program!H${row}`);
+  }
   while (runSheet.getRange(1, columnIndex + 1).getValue() != "") {
     let currentColumn: string = columns[columnIndex].toString();
     let maxRowNumber: number = getLastActiveRowNumber(currentColumn, runSheet);
@@ -516,7 +520,7 @@ function relocateMemory() {
     .getRange(3, letterToIndex(provAddressColumn) + 1, formulas.length)
     .setFormulas(
       formulas.map((_, index) => [
-        `=RIGHT(${provSegmentsColumn}${index + 3};LEN(${provSegmentsColumn}${index + 3}) - 5)`,
+        `=REGEXEXTRACT(${provSegmentsColumn}${index + 3}; "([A-Z]+[0-9]+)$")`,
       ]),
     );
 

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -26,6 +26,8 @@ const runOp1Column: String = columns[i];
 i++;
 const executionColumn: String = columns[i];
 i++;
+const firstBuiltinColumn: String = columns[i];
+i++;
 
 let j = 0;
 const progBytecodeColumn: String = columns[j];
@@ -41,6 +43,14 @@ j++;
 const progApupdateColumn: String = columns[j];
 j++;
 const progFpupdateColumn: String = columns[j];
+j++;
+const progDecInstructionColumn: String = columns[j];
+j++;
+const progDstOffsetColumn: String = columns[j];
+j++;
+const progOp0OffsetColumn: String = columns[j];
+j++;
+const progOp1OffsetColumn: String = columns[j];
 j++;
 
 let k = 0;

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -241,7 +241,8 @@ function step(n: number = 0): void {
       op1Addr = `${op0Value[0]}${Number(op0Value.substring(1)) + instruction.Op1Offset}`;
       break;
     case Op1Src.PC:
-      op1Index = registers[instruction.Op1Register] + instruction.Op1Offset;
+      op1Index =
+        Number(registers[instruction.Op1Register]) + instruction.Op1Offset;
       op1Addr = `Program!${progOpColumn}${op1Index + 2}`;
       break;
     default:
@@ -551,7 +552,7 @@ function runUntilPc(): number {
     i++;
     pc = runSheet.getRange(`${pcColumn}${i + 1 + 1}`).getValue();
   }
-  return i + 1; //number of steps exectued
+  return i + 1; //number of steps exectued (i+2 is the row of the new registers)
 }
 
 function relocateMemory() {

--- a/src/vm/vm.ts
+++ b/src/vm/vm.ts
@@ -77,9 +77,10 @@ type Builtins = {
   output: BuitlinType;
   pedersen: BuitlinType;
   range_check: BuitlinType;
+  range_check96: BuitlinType;
   ecdsa: BuitlinType;
   bitwise: BuitlinType;
-  ecOp: BuitlinType;
+  ec_op: BuitlinType;
   keccak: BuitlinType;
   poseidon: BuitlinType;
 };
@@ -88,7 +89,7 @@ let builtins: Builtins = {
   output: {
     freeCellsPerBuiltin: 0,
     column: "",
-    functionName: ["output"],
+    functionName: ["OUTPUT"],
   },
   pedersen: {
     freeCellsPerBuiltin: 2,
@@ -100,13 +101,26 @@ let builtins: Builtins = {
     column: "",
     functionName: ["RANGE_CHECK"],
   },
-  ecdsa: null,
+  range_check96: {
+    freeCellsPerBuiltin: 0,
+    column: "",
+    functionName: ["RANGE_CHECK96"],
+  },
+  ecdsa: {
+    freeCellsPerBuiltin: 3,
+    column: "",
+    functionName: ["CHECK_ECDSA_SIGNATURE"],
+  },
   bitwise: {
     freeCellsPerBuiltin: 2,
     column: "",
     functionName: ["BITWISE_AND", "BITWISE_XOR", "BITWISE_OR"],
   },
-  ecOp: null,
+  ec_op: {
+    freeCellsPerBuiltin: 3,
+    column: "",
+    functionName: ["EC_OP"],
+  },
   keccak: {
     freeCellsPerBuiltin: 1,
     column: "",


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title -->

Add proof mode and prepare trace creation

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 2 days

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying,
or link to a relevant issue. -->

## What is the new behavior?

A few changes are made to prepare the creation of the trace and more generally the prover:
- the program segment is now added to the relocated memory as the program segment is a segment like any other,
-  the VM now displays the values taken by op1 and op0 as they will be needed for the trace layout (this will allow us to use formulas and not "hard-coded" values),
- in the the program tab there is now : the offsets of the instructions and the flags that will be used in the trace (which are computed as explained in the cairo wp page 51).
- the program tab also included a new section "complementary information" which allows us to store settings of the execution and program (as once the program is loaded and the gs page refreshed, there is no way to get those settings)
- When loading a file there is now the possibility to pick if the execution should be done in proof mode or not. The layout can also be selected there. Note that for now there are only recursive and plain layouts. Also you should change the layout and the execution mode before loading the file (as loading the file acts like a "submit" button). The prover mode has different initial configuration and adds instructions (that act like a bootloader) to loop once the final pc is reached.
- in prover mode "run" will have the last step repeated so that the number of steps is a power of 2 which is necessary for the trace.