### PR TITLE
feat: added framework for annotations and tutorials

### DIFF
--- a/src/ui/tutorials/fibonacci/program.ts
+++ b/src/ui/tutorials/fibonacci/program.ts
@@ -1,0 +1,648 @@
+const FIBONACCI_PROGRAM = JSON.stringify(
+  {
+    attributes: [],
+    builtins: [],
+    compiler_version: "0.13.1",
+    data: [
+      "0x482680017ffd8000",
+      "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffff",
+      "0x480680017fff8000",
+      "0x1",
+      "0x480680017fff8000",
+      "0x1",
+      "0x482480017ffd8000",
+      "0x800000000000011000000000000000000000000000000000000000000000000",
+      "0x48127ffe7fff8000",
+      "0x48307ffd7ffc8000",
+      "0x20680017fff7ffd",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffd",
+      "0x208b7fff7fff7ffe",
+      "0x480680017fff8000",
+      "0x4",
+      "0x1104800180018000",
+      "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff2",
+      "0x208b7fff7fff7ffe",
+    ],
+    debug_info: {
+      file_contents: {},
+      instruction_locations: {
+        "0": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 0,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.n": 0,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 22,
+            end_line: 2,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 17,
+            start_line: 2,
+          },
+        },
+        "2": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 1,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.n": 1,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 18,
+            end_line: 3,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 17,
+            start_line: 3,
+          },
+        },
+        "4": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 2,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 2,
+              "fibonacci.fibonacci.n": 1,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 18,
+            end_line: 4,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 17,
+            start_line: 4,
+          },
+        },
+        "6": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 3,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 5,
+              "fibonacci.fibonacci.j": 6,
+              "fibonacci.fibonacci.n": 4,
+              "fibonacci.fibonacci.next": 7,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 22,
+            end_line: 12,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 17,
+            start_line: 12,
+          },
+        },
+        "8": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 4,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 5,
+              "fibonacci.fibonacci.j": 6,
+              "fibonacci.fibonacci.n": 8,
+              "fibonacci.fibonacci.next": 7,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 21,
+            end_line: 9,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            parent_location: [
+              {
+                end_col: 18,
+                end_line: 13,
+                input_file: {
+                  filename:
+                    "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+                },
+                start_col: 17,
+                start_line: 13,
+              },
+              "While expanding the reference 'j' in:",
+            ],
+            start_col: 13,
+            start_line: 9,
+          },
+        },
+        "9": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 5,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 9,
+              "fibonacci.fibonacci.j": 6,
+              "fibonacci.fibonacci.n": 8,
+              "fibonacci.fibonacci.next": 7,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 21,
+            end_line: 10,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            parent_location: [
+              {
+                end_col: 21,
+                end_line: 14,
+                input_file: {
+                  filename:
+                    "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+                },
+                start_col: 17,
+                start_line: 14,
+              },
+              "While expanding the reference 'next' in:",
+            ],
+            start_col: 16,
+            start_line: 10,
+          },
+        },
+        "10": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 6,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 9,
+              "fibonacci.fibonacci.j": 10,
+              "fibonacci.fibonacci.n": 8,
+              "fibonacci.fibonacci.next": 7,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 23,
+            end_line: 20,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 5,
+            start_line: 20,
+          },
+        },
+        "12": {
+          accessible_scopes: ["fibonacci", "fibonacci.fibonacci"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 0,
+              offset: 6,
+            },
+            reference_ids: {
+              "fibonacci.fibonacci.i": 12,
+              "fibonacci.fibonacci.j": 13,
+              "fibonacci.fibonacci.n": 11,
+              "fibonacci.fibonacci.next": 7,
+            },
+          },
+          hints: [],
+          inst: {
+            end_col: 14,
+            end_line: 27,
+            input_file: {
+              filename:
+                "/home/antoine/Documents/cairo-vm-gs/cairo0/fibonacci.cairo",
+            },
+            start_col: 5,
+            start_line: 27,
+          },
+        },
+        "13": {
+          accessible_scopes: ["__main__", "__main__.main"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 1,
+              offset: 0,
+            },
+            reference_ids: {},
+          },
+          hints: [],
+          inst: {
+            end_col: 16,
+            end_line: 4,
+            input_file: {
+              filename: "../../cairo0-test/fibonacci/main.cairo",
+            },
+            start_col: 15,
+            start_line: 4,
+          },
+        },
+        "15": {
+          accessible_scopes: ["__main__", "__main__.main"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 1,
+              offset: 1,
+            },
+            reference_ids: {},
+          },
+          hints: [],
+          inst: {
+            end_col: 17,
+            end_line: 4,
+            input_file: {
+              filename: "../../cairo0-test/fibonacci/main.cairo",
+            },
+            start_col: 5,
+            start_line: 4,
+          },
+        },
+        "17": {
+          accessible_scopes: ["__main__", "__main__.main"],
+          flow_tracking_data: {
+            ap_tracking: {
+              group: 2,
+              offset: 0,
+            },
+            reference_ids: {},
+          },
+          hints: [],
+          inst: {
+            end_col: 15,
+            end_line: 5,
+            input_file: {
+              filename: "../../cairo0-test/fibonacci/main.cairo",
+            },
+            start_col: 5,
+            start_line: 5,
+          },
+        },
+      },
+    },
+    hints: {},
+    identifiers: {
+      "__main__.fibonacci": {
+        destination: "fibonacci.fibonacci",
+        type: "alias",
+      },
+      "__main__.main": {
+        decorators: [],
+        pc: 13,
+        type: "function",
+      },
+      "__main__.main.Args": {
+        full_name: "__main__.main.Args",
+        members: {},
+        size: 0,
+        type: "struct",
+      },
+      "__main__.main.ImplicitArgs": {
+        full_name: "__main__.main.ImplicitArgs",
+        members: {},
+        size: 0,
+        type: "struct",
+      },
+      "__main__.main.Return": {
+        cairo_type: "()",
+        type: "type_definition",
+      },
+      "__main__.main.SIZEOF_LOCALS": {
+        type: "const",
+        value: 0,
+      },
+      "fibonacci.fibonacci": {
+        decorators: [],
+        pc: 0,
+        type: "function",
+      },
+      "fibonacci.fibonacci.Args": {
+        full_name: "fibonacci.fibonacci.Args",
+        members: {
+          n: {
+            cairo_type: "felt",
+            offset: 0,
+          },
+        },
+        size: 1,
+        type: "struct",
+      },
+      "fibonacci.fibonacci.ImplicitArgs": {
+        full_name: "fibonacci.fibonacci.ImplicitArgs",
+        members: {},
+        size: 0,
+        type: "struct",
+      },
+      "fibonacci.fibonacci.Return": {
+        cairo_type: "felt",
+        type: "type_definition",
+      },
+      "fibonacci.fibonacci.SIZEOF_LOCALS": {
+        type: "const",
+        value: 0,
+      },
+      "fibonacci.fibonacci.body": {
+        pc: 6,
+        type: "label",
+      },
+      "fibonacci.fibonacci.end": {
+        pc: 12,
+        type: "label",
+      },
+      "fibonacci.fibonacci.i": {
+        cairo_type: "felt",
+        full_name: "fibonacci.fibonacci.i",
+        references: [
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 2,
+            },
+            pc: 4,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 3,
+            },
+            pc: 6,
+            value: "[cast(ap + (-2), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 5,
+            },
+            pc: 9,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 6,
+            },
+            pc: 12,
+            value: "[cast(ap + (-2), felt*)]",
+          },
+        ],
+        type: "reference",
+      },
+      "fibonacci.fibonacci.j": {
+        cairo_type: "felt",
+        full_name: "fibonacci.fibonacci.j",
+        references: [
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 3,
+            },
+            pc: 6,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 3,
+            },
+            pc: 6,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 6,
+            },
+            pc: 10,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 6,
+            },
+            pc: 12,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+        ],
+        type: "reference",
+      },
+      "fibonacci.fibonacci.n": {
+        cairo_type: "felt",
+        full_name: "fibonacci.fibonacci.n",
+        references: [
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 0,
+            },
+            pc: 0,
+            value: "[cast(fp + (-3), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 1,
+            },
+            pc: 2,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 3,
+            },
+            pc: 6,
+            value: "[cast(ap + (-3), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 4,
+            },
+            pc: 8,
+            value: "[cast(ap + (-1), felt*)]",
+          },
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 6,
+            },
+            pc: 12,
+            value: "[cast(ap + (-3), felt*)]",
+          },
+        ],
+        type: "reference",
+      },
+      "fibonacci.fibonacci.next": {
+        cairo_type: "felt",
+        full_name: "fibonacci.fibonacci.next",
+        references: [
+          {
+            ap_tracking_data: {
+              group: 0,
+              offset: 3,
+            },
+            pc: 6,
+            value: "cast([ap + (-2)] + [ap + (-1)], felt)",
+          },
+        ],
+        type: "reference",
+      },
+    },
+    main_scope: "__main__",
+    prime: "0x800000000000011000000000000000000000000000000000000000000000001",
+    reference_manager: {
+      references: [
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 0,
+          },
+          pc: 0,
+          value: "[cast(fp + (-3), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 1,
+          },
+          pc: 2,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 2,
+          },
+          pc: 4,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 3,
+          },
+          pc: 6,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 3,
+          },
+          pc: 6,
+          value: "[cast(ap + (-3), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 3,
+          },
+          pc: 6,
+          value: "[cast(ap + (-2), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 3,
+          },
+          pc: 6,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 3,
+          },
+          pc: 6,
+          value: "cast([ap + (-2)] + [ap + (-1)], felt)",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 4,
+          },
+          pc: 8,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 5,
+          },
+          pc: 9,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 6,
+          },
+          pc: 10,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 6,
+          },
+          pc: 12,
+          value: "[cast(ap + (-3), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 6,
+          },
+          pc: 12,
+          value: "[cast(ap + (-2), felt*)]",
+        },
+        {
+          ap_tracking_data: {
+            group: 0,
+            offset: 6,
+          },
+          pc: 12,
+          value: "[cast(ap + (-1), felt*)]",
+        },
+      ],
+    },
+  },
+  null,
+  2,
+);

--- a/src/ui/tutorials/fibonacci/steps.ts
+++ b/src/ui/tutorials/fibonacci/steps.ts
@@ -1,0 +1,32 @@
+const FIBONACCI: string = "Fibonacci";
+
+function startFibonacci() {
+  loadProgram(FIBONACCI_PROGRAM, "Execution", "plain");
+  startTutorial(FIBONACCI);
+  addNotesFibonacci();
+}
+
+function addNotesFibonacci() {
+  addNotes(FIBONACCI);
+}
+
+const stepsFibonacci: Step[] = [
+  {
+    cell: "A1",
+    sheetName: "Run",
+    message:
+      "This is the starting point of the Fibonacci tutorial. Go to the next step to execute the fibonacci program on the GS CairoVM !",
+    action: () => SpreadsheetApp.getActiveSpreadsheet().toast("Hey !"),
+  },
+  {
+    cell: "A1",
+    sheetName: "Run",
+    message: "The script is running...",
+    action: menuRun,
+  },
+  {
+    cell: "C3",
+    sheetName: "Program",
+    message: "There we go.",
+  },
+];

--- a/src/ui/tutorials/tutorials.ts
+++ b/src/ui/tutorials/tutorials.ts
@@ -1,0 +1,110 @@
+interface Step {
+  cell: string;
+  sheetName: string;
+  message: string;
+  action?: () => void;
+}
+
+const steps = {
+  Fibonacci: stepsFibonacci,
+};
+
+function startTutorial(tutorialName: string) {
+  clearNotes();
+
+  const ui = SpreadsheetApp.getUi();
+
+  const response = ui.alert(
+    `${tutorialName} Tutorial`,
+    `Welcome to the ${tutorialName} tutorial!
+        \nThis tutorial consists of cell annotations being shown to you so that you get a better understanding of the CairoVM.
+        \nThe cell associated to a step of the tutorial has a yellow background and you can see its annotation by hovering the cell.
+        \nOnce you are done with reading the note, go in the "Tutorial" menu and click "Next".
+        \nClick "Ok" to begin.`,
+    ui.ButtonSet.OK,
+  );
+
+  if (response === ui.Button.OK) {
+    const offset: number = Object.keys(steps).includes(getTutorialName())
+      ? -1
+      : 0;
+    programSheet
+      .getRange(programSheet.getLastRow() + 1 + offset, 2)
+      .setValue(0);
+    programSheet.getRange(programSheet.getLastRow(), 1).setValue(tutorialName);
+    doStepTuto(0, tutorialName);
+  }
+}
+
+function doStepTuto(stepIndex: number, tutorialName: string) {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+
+  //Clear previous step background
+  const previousStepIndex = stepIndex == 0 ? 0 : stepIndex - 1;
+  const previousStep = steps[tutorialName][previousStepIndex];
+  const previousSheet = spreadsheet.getSheetByName(previousStep.sheetName);
+  previousSheet.getRange(previousStep.cell).setBackground("white");
+
+  //Set focus on step cell
+  const currentStep = steps[tutorialName][stepIndex];
+  const currentSheet = spreadsheet.getSheetByName(currentStep.sheetName);
+
+  const range = currentSheet.getRange(currentStep.cell);
+  range.setBackground("yellow");
+  currentSheet.activate();
+  currentSheet.setActiveRange(range);
+
+  //Execute action related to step
+  if (currentStep.action) {
+    currentStep.action();
+  }
+}
+
+function nextStepTuto() {
+  const previousStepIndex = getStepIndex();
+  const tutorialName: string = getTutorialName();
+
+  if (previousStepIndex < steps[tutorialName].length - 1) {
+    doStepTuto(previousStepIndex + 1, tutorialName);
+    programSheet
+      .getRange(programSheet.getLastRow(), 2)
+      .setValue(previousStepIndex + 1);
+  } else {
+    const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+    const previousStep = steps[tutorialName][previousStepIndex];
+    const previousSheet = spreadsheet.getSheetByName(previousStep.sheetName);
+    previousSheet.getRange(previousStep.cell).setBackground("white");
+
+    SpreadsheetApp.getUi().alert(
+      `You have completed the ${tutorialName} tutorial!`,
+    );
+  }
+}
+
+function clearNotes() {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const sheets = spreadsheet.getSheets();
+
+  sheets.forEach((sheet) => {
+    const range = sheet.getDataRange(); // Get the range of all data in the sheet
+    range.clearNote(); // Clear all notes in the range
+  });
+}
+
+function addNotes(tutorialName: string) {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+
+  steps[tutorialName].forEach((step: Step) => {
+    const sheet = spreadsheet.getSheetByName(step.sheetName);
+    const range = sheet.getRange(step.cell);
+    range.setNote(step.message);
+  });
+}
+
+function getTutorialName(): string {
+  return String(programSheet.getRange(programSheet.getLastRow(), 1).getValue());
+}
+
+function getStepIndex(): number {
+  return Number(programSheet.getRange(programSheet.getLastRow(), 2).getValue());
+}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -7,6 +7,13 @@ function onOpen(): void {
     .addItem("Load Program", "showPicker")
     .addItem("Relocate", "relocate")
     .addToUi();
+
+  ui.createMenu("Tutorials")
+    .addItem("Fibonacci - add notes", "addNotesFibonacci")
+    .addItem("Fibonacci - start tutorial", "startFibonacci")
+    .addItem("Next", "nextStepTuto")
+    .addItem("Clear notes", "clearNotes")
+    .addToUi();
 }
 
 function menuStep(): void {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title -->

feat: added framework for annotations and tutorials

<!-- Give an estimate of the time you spent on this PR in terms of work days.
Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 0.42 days

## Pull request type

<!-- Please try to limit your pull request to one type,
submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Resolves #69 

## What is the new behavior?

The project is ready to welcome tutorials. They work like so:
- the user chooses a tutorial from the "Tutorial" menu and clicks on "[TUTORIAL] - start",
- then annotations are added to the sheet at specific locations defined by the tutorial implementer (they can be seen by hovering the cells that have a triangle in their top right corner).
- the "tutorial" is basically a focus changer mecanism: when the user clicks on "Next" in the Tutorial menu, the backend sets the focus on a given cell in a given sheet. It also highlights the background (for it to be easy to find the current cell if the focus is lost).
- but for each step, the tutorial implementer can also define a function that will be executed. This leaves space for guided and interactive demos.